### PR TITLE
Rename API functions and routings for POI rating to make it consistent

### DIFF
--- a/cds/web/poi_rating.go
+++ b/cds/web/poi_rating.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func (s *Server) AddPOIRating(c *gin.Context) {
+func (s *Server) SetPOIRating(c *gin.Context) {
 	accountNumber := c.GetString("account_number")
 	poiID := c.Param("poi_id")
 
@@ -19,7 +19,7 @@ func (s *Server) AddPOIRating(c *gin.Context) {
 		return
 	}
 
-	err := s.dataStorePool.Community().AddPOIRating(c, accountNumber, poiID, params.Ratings)
+	err := s.dataStorePool.Community().SetPOIRating(c, accountNumber, poiID, params.Ratings)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/cds/web/server.go
+++ b/cds/web/server.go
@@ -65,7 +65,7 @@ func (s *Server) setupRouter() *gin.Engine {
 
 	poiRatingRoute := r.Group("/poi_rating")
 	poiRatingRoute.GET("/:poi_id", s.GetPOISummarizedRating)
-	poiRatingRoute.POST("/:poi_id", s.AddPOIRating)
+	poiRatingRoute.PUT("/:poi_id", s.SetPOIRating)
 
 	return r
 }

--- a/store/mongo.go
+++ b/store/mongo.go
@@ -20,12 +20,12 @@ type DataStorePool interface {
 }
 
 type PersonalDataStore interface {
-	RatePOIResource(ctx context.Context, poiID string, ratings map[string]float64) error
-	GetPOIResource(ctx context.Context, poiID string) (map[string]float64, error)
+	SetPOIRating(ctx context.Context, poiID string, ratings map[string]float64) error
+	GetPOIRating(ctx context.Context, poiID string) (map[string]float64, error)
 }
 
 type CommunityDataStore interface {
-	AddPOIRating(ctx context.Context, accountNumber, poiID string, ratings map[string]float64) error
+	SetPOIRating(ctx context.Context, accountNumber, poiID string, ratings map[string]float64) error
 	GetPOISummarizedRating(ctx context.Context, poiID string) (POISummarizedRating, error)
 }
 

--- a/store/poi.go
+++ b/store/poi.go
@@ -13,7 +13,7 @@ type POIResourceRating struct {
 	Ratings map[string]float64 `bson:"ratings"`
 }
 
-func (m *mongoAccountStore) RatePOIResource(ctx context.Context, poiID string, ratings map[string]float64) error {
+func (m *mongoAccountStore) SetPOIRating(ctx context.Context, poiID string, ratings map[string]float64) error {
 
 	_, err := m.Resource("poi_ratings").UpdateOne(ctx,
 		bson.M{"id": poiID},
@@ -29,7 +29,7 @@ func (m *mongoAccountStore) RatePOIResource(ctx context.Context, poiID string, r
 	return nil
 }
 
-func (m *mongoAccountStore) GetPOIResource(ctx context.Context, poiID string) (map[string]float64, error) {
+func (m *mongoAccountStore) GetPOIRating(ctx context.Context, poiID string) (map[string]float64, error) {
 	var rating POIResourceRating
 
 	if err := m.Resource("poi_ratings").FindOne(ctx, bson.M{"id": poiID}).Decode(&rating); err != nil {
@@ -39,7 +39,7 @@ func (m *mongoAccountStore) GetPOIResource(ctx context.Context, poiID string) (m
 	return rating.Ratings, nil
 }
 
-func (m *mongoCommunityStore) AddPOIRating(ctx context.Context, accountNumber, poiID string, ratings map[string]float64) error {
+func (m *mongoCommunityStore) SetPOIRating(ctx context.Context, accountNumber, poiID string, ratings map[string]float64) error {
 	_, err := m.Resource("poi_ratings").UpdateOne(ctx,
 		bson.M{"id": poiID, "account_number": accountNumber},
 		bson.M{

--- a/web/poi_rating.go
+++ b/web/poi_rating.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func (s *Server) RatePOIResource(c *gin.Context) {
+func (s *Server) SetPOIRating(c *gin.Context) {
 	accountNumber := c.GetString("account_number")
 	poiID := c.Param("poi_id")
 
@@ -19,7 +19,7 @@ func (s *Server) RatePOIResource(c *gin.Context) {
 		return
 	}
 
-	err := s.dataStorePool.Account(accountNumber).RatePOIResource(c, poiID, params.Ratings)
+	err := s.dataStorePool.Account(accountNumber).SetPOIRating(c, poiID, params.Ratings)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -28,11 +28,11 @@ func (s *Server) RatePOIResource(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"result": "ok"})
 }
 
-func (s *Server) GetPOIResource(c *gin.Context) {
+func (s *Server) GetPOIRating(c *gin.Context) {
 	accountNumber := c.GetString("account_number")
 	poiID := c.Param("poi_id")
 
-	r, err := s.dataStorePool.Account(accountNumber).GetPOIResource(c, poiID)
+	r, err := s.dataStorePool.Account(accountNumber).GetPOIRating(c, poiID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/web/server.go
+++ b/web/server.go
@@ -52,8 +52,8 @@ func (s *Server) setupRouter() *gin.Engine {
 
 	poiRatingRoute := r.Group("/poi_rating")
 	poiRatingRoute.Use(s.checkMacaroon())
-	poiRatingRoute.GET("/:poi_id", s.GetPOIResource)
-	poiRatingRoute.POST("", s.RatePOIResource)
+	poiRatingRoute.GET("/:poi_id", s.GetPOIRating)
+	poiRatingRoute.PUT("/:poi_id", s.SetPOIRating)
 
 	return r
 }


### PR DESCRIPTION
In this PR, we rename the API calls between PDS and CDS to make the naming consistent.