### PR TITLE
rm request params and then define target resource

### DIFF
--- a/web/middleware.go
+++ b/web/middleware.go
@@ -77,7 +77,12 @@ func (s *Server) CheckMacaroon() gin.HandlerFunc {
 					}
 				}
 			case "resources":
-				parts := strings.Split(c.Request.URL.Path, "/")
+				path := c.Request.URL.Path
+				for _, param := range c.Params {
+					path = strings.Replace(path, param.Value, "", -1)
+				}
+				path = strings.TrimRight(path, "/")
+				parts := strings.Split(path, "/")
 				targetResource := parts[len(parts)-1]
 				allowedResources := strings.Split(arg, ",")
 				valid := false


### PR DESCRIPTION
Remove all the request parameters and extract the last part as the targeted resource.

For example, 
`/poi_rating/x` → `poi_rating` (`x` was considered as the targeted resource before this fix)
`/poi_rating/` → `poi_rating`
`/poi_rating` → `poi_rating`