### PR TITLE
Create a DB indexing mechanism for PDS and CDS

### DIFF
--- a/Dockerfile-cds
+++ b/Dockerfile-cds
@@ -9,12 +9,13 @@ RUN go mod download
 ADD . .
 
 RUN go install github.com/bitmark-inc/data-store/commands/cds
-
+RUN go install github.com/bitmark-inc/data-store/commands/migrate
 
 # ---
 
 FROM alpine:3.10.3
 ARG dist=0.0
 COPY --from=build /go/bin/cds /
+COPY --from=build /go/bin/migrate /
 
 CMD ["/cds"]

--- a/cds/poi_rating.go
+++ b/cds/poi_rating.go
@@ -22,7 +22,7 @@ func (cds *CDS) SetPOIRating() gin.HandlerFunc {
 			return
 		}
 
-		err := cds.dataStorePool.Community("").SetPOIRating(c, accountNumber, poiID, params.Ratings)
+		err := cds.dataStorePool.Community().SetPOIRating(c, accountNumber, poiID, params.Ratings)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -37,7 +37,7 @@ func (cds *CDS) GetPOISummarizedRatings(c *gin.Context) {
 	var result map[string]store.POISummarizedRating
 	var err error
 	if poiID != "" {
-		result, err = cds.dataStorePool.Community("").GetPOISummarizedRatings(c, []string{poiID})
+		result, err = cds.dataStorePool.Community().GetPOISummarizedRatings(c, []string{poiID})
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -54,7 +54,7 @@ func (cds *CDS) GetPOISummarizedRatings(c *gin.Context) {
 
 		poiIDs := strings.Split(params.POIIDs, ",")
 
-		result, err = cds.dataStorePool.Community("").GetPOISummarizedRatings(c, poiIDs)
+		result, err = cds.dataStorePool.Community().GetPOISummarizedRatings(c, poiIDs)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/cds/symptom_report.go
+++ b/cds/symptom_report.go
@@ -20,7 +20,7 @@ func (cds *CDS) AddSymptomDailyReports(c *gin.Context) {
 		return
 	}
 
-	if err := cds.dataStorePool.Community("").AddSymptomDailyReports(c, body.Reports); err != nil {
+	if err := cds.dataStorePool.Community().AddSymptomDailyReports(c, body.Reports); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -61,12 +61,12 @@ func (cds *CDS) GetSymptomReportItems(c *gin.Context) {
 	prevStart := start.Add(gap)
 	prevEnd := start
 
-	current, err := cds.dataStorePool.Community("").GetSymptomReportItems(c, start.Format("2006-01-02"), end.Format("2006-01-02"))
+	current, err := cds.dataStorePool.Community().GetSymptomReportItems(c, start.Format("2006-01-02"), end.Format("2006-01-02"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	previous, err := cds.dataStorePool.Community("").GetSymptomReportItems(c, prevStart.Format("2006-01-02"), prevEnd.Format("2006-01-02"))
+	previous, err := cds.dataStorePool.Community().GetSymptomReportItems(c, prevStart.Format("2006-01-02"), prevEnd.Format("2006-01-02"))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/commands/cds/config.yaml.sample
+++ b/commands/cds/config.yaml.sample
@@ -3,6 +3,7 @@ server:
   port: 8080
   macaroon_root_key: <MACAROON_ROOT_KEY>
   bitmark_account_seed: <BITMARK_ACCOUNT_SEED>
+  store_prefix: "autonomy_"
 bitmarksdk:
   token: <API_TOKEN>
   network: testnet

--- a/commands/cds/main.go
+++ b/commands/cds/main.go
@@ -136,7 +136,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	cds := cds.New(store.NewMongodbDataPool(mongoClient))
+	cds := cds.New(store.NewMongodbDataPool(mongoClient, viper.GetString("server.store_prefix")))
 
 	// Init http server
 	server = web.NewServer(viper.GetBool("server.tracing"), acct.(*account.AccountV2), viper.GetString("server.endpoint"), rootKey)

--- a/commands/migrate/main.go
+++ b/commands/migrate/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/bitmark-inc/data-store/store"
+	"github.com/spf13/viper"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func loadConfig(file string) {
+	// Config from file
+	viper.SetConfigType("yaml")
+	if file != "" {
+		viper.SetConfigFile(file)
+	}
+
+	viper.AddConfigPath("/.config/")
+	viper.AddConfigPath(".")
+	err := viper.ReadInConfig()
+	if err != nil {
+		fmt.Println("No config file. Read config from env.")
+		viper.AllowEmptyEnv(false)
+	}
+
+	// Config from env if possible
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("ds")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+}
+
+func main() {
+	var configFile string
+	flag.StringVar(&configFile, "c", "./config.yaml", "[optional] path of configuration file")
+	flag.Parse()
+
+	loadConfig(configFile)
+
+	opts := options.Client().ApplyURI(viper.GetString("mongo.conn"))
+	opts.SetMaxPoolSize(viper.GetUint64("mongo.pool"))
+	mongoClient, err := mongo.NewClient(opts)
+	if nil != err {
+		log.Panicf("create mongo client with error: %s", err)
+	}
+
+	if err := mongoClient.Connect(context.Background()); nil != err {
+		log.Panicf("connect mongo database with error: %s", err)
+	}
+
+	if err := store.NewMongodbDataPool(mongoClient, viper.GetString("server.store_prefix")).InitCommunityStore(); err != nil {
+		log.Panicf("initiate community store with error: %s", err)
+	}
+}

--- a/commands/pds/config.yaml.sample
+++ b/commands/pds/config.yaml.sample
@@ -3,6 +3,7 @@ server:
   port: 8080
   macaroon_root_key: <MACAROON_ROOT_KEY>
   bitmark_account_seed: <BITMARK_ACCOUNT_SEED>
+  store_prefix: "autonomy_"
 bitmarksdk:
   token: <API_TOKEN>
   network: testnet

--- a/commands/pds/main.go
+++ b/commands/pds/main.go
@@ -136,7 +136,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	pds := pds.New(store.NewMongodbDataPool(mongoClient))
+	pds := pds.New(store.NewMongodbDataPool(mongoClient, viper.GetString("server.store_prefix")))
 
 	// Init http server
 	server = web.NewServer(viper.GetBool("server.tracing"), acct.(*account.AccountV2), viper.GetString("server.endpoint"), rootKey)

--- a/store/registration.go
+++ b/store/registration.go
@@ -1,0 +1,46 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func indexForPersonalAccountStore(db *mongo.Database) error {
+	_, err := db.Collection("poi_ratings").Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{"id", 1},
+			},
+			Options: options.Index().SetUnique(true).SetName("id_unique"),
+		},
+	})
+	return err
+}
+
+func indexForCommunityStore(db *mongo.Database) error {
+	_, err := db.Collection("poi_ratings").Indexes().CreateMany(context.Background(), []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{"account_number", 1},
+				{"id", 1},
+			},
+			Options: options.Index().SetUnique(true).SetName("id_account_unique"),
+		},
+	})
+	return err
+}
+
+// Account returns a personal data store.
+func (m mongodbDataPool) RegisterAccount(accountNumber string) error {
+	dbName := fmt.Sprintf("%s%s", m.dbPrefix, accountNumber)
+	return indexForPersonalAccountStore(m.client.Database(dbName))
+}
+
+func (m mongodbDataPool) InitCommunityStore() error {
+	dbName := fmt.Sprintf("%scommunity", m.dbPrefix)
+	return indexForCommunityStore(m.client.Database(dbName))
+}


### PR DESCRIPTION
There are two kinds of data stores in this project, personal and community. For community store, all data stores in a single database so we only need to create a program to generate indexes all at once. Personal data store, on the other hand, contains varies of databases based on account_number. That means we need to create indexes for all of them separately.

To achieve this goal, we have the following changes:

1. Create a migrate tool to generate indexes for community store. In the meantime, we make the `prefix` as a attribute of `dataStorePool` so we can have a namespace to both personal and community databases. That make the database management easier.
2. For personal store, it is hard to find a good place to create indexes under current service design. Since mongodb will not do anything if we are going to create an existent index, we insert the index function at the time before a `PersonalDataStore` is returned by `Account` function.