### PR TITLE
handle aggregated symptom report generated by berkeley

### DIFF
--- a/cds/symptom_report.go
+++ b/cds/symptom_report.go
@@ -94,7 +94,11 @@ func (cds *CDS) GetSymptomReportItems(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	currEnd, _ := time.Parse("2006-01-02", latestReport.Date)
+	currEnd, err := time.Parse("2006-01-02", latestReport.Date)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	prevEnd := currEnd.Add(-time.Hour * 24 * time.Duration(days))
 
 	current, err := cds.dataStorePool.Community().GetSymptomReportItems(c, currEnd.Format("2006-01-02"), days)

--- a/cds/symptom_report_test.go
+++ b/cds/symptom_report_test.go
@@ -1,0 +1,43 @@
+package cds
+
+import (
+	"testing"
+
+	"github.com/bitmark-inc/data-store/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransformToSymptomDailyReports(t *testing.T) {
+	lines := [][]string{
+		{"symptoms", "2020-07-19", "2020-07-20", "2020-07-21"},
+		{"Cough", "10", "7", "8"},
+		{"Fatigue", "18", "28", "29"},
+		{"numberCheckInOnce_Last3days", "NA", "NA", "1003"},
+	}
+	reports := transformToSymptomDailyReports(lines)
+	assert.Equal(t, []store.SymptomDailyReport{
+		{
+			Date: "2020-07-19",
+			Symptoms: []store.SymptomStats{
+				{Name: "Cough", Count: 10},
+				{Name: "Fatigue", Count: 18},
+			},
+			CheckinsNumPastThreeDays: 0,
+		},
+		{
+			Date: "2020-07-20",
+			Symptoms: []store.SymptomStats{
+				{Name: "Cough", Count: 7},
+				{Name: "Fatigue", Count: 28},
+			},
+			CheckinsNumPastThreeDays: 0,
+		},
+		{
+			Date: "2020-07-21",
+			Symptoms: []store.SymptomStats{
+				{Name: "Cough", Count: 8},
+				{Name: "Fatigue", Count: 29},
+			},
+			CheckinsNumPastThreeDays: 1003,
+		}}, reports)
+}

--- a/commands/cds/main.go
+++ b/commands/cds/main.go
@@ -144,10 +144,8 @@ func main() {
 	server.Route("PUT", "/poi_rating/:poi_id", server.CheckMacaroon(), cds.SetPOIRating())
 	server.Route("GET", "/poi_rating/:poi_id", server.CheckMacaroon(), cds.GetPOISummarizedRatings)
 	server.Route("GET", "/poi_rating", server.CheckMacaroon(), cds.GetPOISummarizedRatings)
-	// server.Route("POST", "/symptom-daily-reports", server.CheckMacaroon(), cds.AddSymptomDailyReports)
-	server.Route("POST", "/symptom-daily-reports", cds.AddSymptomDailyReports)
-	// server.Route("GET", "/report-items", server.CheckMacaroon(), cds.GetSymptomReportItems)
-	server.Route("GET", "/report-items", cds.GetSymptomReportItems)
+	server.Route("POST", "/symptom-daily-reports", server.CheckMacaroon(), cds.AddSymptomDailyReports)
+	server.Route("GET", "/report-items", server.CheckMacaroon(), cds.GetSymptomReportItems)
 	server.Route("GET", "/data/export", server.CheckMacaroon(), cds.ExportData)
 	log.WithField("prefix", "init").Info("Initialized http server")
 

--- a/commands/cds/main.go
+++ b/commands/cds/main.go
@@ -144,8 +144,10 @@ func main() {
 	server.Route("PUT", "/poi_rating/:poi_id", server.CheckMacaroon(), cds.SetPOIRating())
 	server.Route("GET", "/poi_rating/:poi_id", server.CheckMacaroon(), cds.GetPOISummarizedRatings)
 	server.Route("GET", "/poi_rating", server.CheckMacaroon(), cds.GetPOISummarizedRatings)
-	server.Route("POST", "/symptom-daily-reports", server.CheckMacaroon(), cds.AddSymptomDailyReports)
-	server.Route("GET", "/report-items", server.CheckMacaroon(), cds.GetSymptomReportItems)
+	// server.Route("POST", "/symptom-daily-reports", server.CheckMacaroon(), cds.AddSymptomDailyReports)
+	server.Route("POST", "/symptom-daily-reports", cds.AddSymptomDailyReports)
+	// server.Route("GET", "/report-items", server.CheckMacaroon(), cds.GetSymptomReportItems)
+	server.Route("GET", "/report-items", cds.GetSymptomReportItems)
 	server.Route("GET", "/data/export", server.CheckMacaroon(), cds.ExportData)
 	log.WithField("prefix", "init").Info("Initialized http server")
 

--- a/store/aggregation.go
+++ b/store/aggregation.go
@@ -92,3 +92,18 @@ func AggregationGeoNear(coordinates []float64, distance int, options ...GeoNearO
 		bson.E{"$geoNear", geoNear},
 	}
 }
+
+// AggregationSort sorts the documents by specified key
+func AggregationSort(key string, order int) bson.D {
+	sort := bson.D{bson.E{key, order}}
+	return bson.D{
+		bson.E{
+			"$sort", sort,
+		},
+	}
+}
+
+// AggregationLimit limits the number of documents in the pipeline
+func AggregationLimit(limit int64) bson.D {
+	return bson.D{{"$limit", limit}}
+}

--- a/store/mongo.go
+++ b/store/mongo.go
@@ -33,7 +33,8 @@ type CommunityDataStore interface {
 	SetPOIRating(ctx context.Context, accountNumber, poiID string, ratings map[string]float64) error
 	GetPOISummarizedRatings(ctx context.Context, poiIDs []string) (map[string]POISummarizedRating, error)
 	AddSymptomDailyReports(ctx context.Context, reports []SymptomDailyReport) error
-	GetSymptomReportItems(ctx context.Context, start, end string) (map[string][]Bucket, error)
+	FindLatestDailyReport(ctx context.Context) (*SymptomDailyReport, error)
+	GetSymptomReportItems(ctx context.Context, end string, limit int64) (map[string][]Bucket, error)
 	ExportData(ctx context.Context, accountNumber string) ([]byte, error)
 }
 

--- a/store/symptom_report.go
+++ b/store/symptom_report.go
@@ -48,6 +48,7 @@ type Bucket struct {
 	Value int    `bson:"value" json:"value"`
 }
 
+// GetSymptomReportItems returns report items in the date range which starts at `limit` days ago, and ends at `end`.
 func (m *mongoCommunityStore) GetSymptomReportItems(ctx context.Context, end string, limit int64) (map[string][]Bucket, error) {
 	pipeline := mongo.Pipeline{
 		AggregationMatch(bson.M{

--- a/store/symptom_report.go
+++ b/store/symptom_report.go
@@ -9,11 +9,14 @@ import (
 )
 
 type SymptomDailyReport struct {
-	Date     string `json:"date"`
-	Symptoms []struct {
-		Name  string `json:"name"`
-		Count int    `json:"count"`
-	} `json:"symptoms"`
+	Date                     string         `bson:"date"`
+	Symptoms                 []SymptomStats `bson:"symptoms"`
+	CheckinsNumPastThreeDays int            `bson:"checkins_num_past_three_days"`
+}
+
+type SymptomStats struct {
+	Name  string `bson:"name"`
+	Count int    `bson:"count"`
 }
 
 func (m *mongoCommunityStore) AddSymptomDailyReports(ctx context.Context, reports []SymptomDailyReport) error {
@@ -22,7 +25,8 @@ func (m *mongoCommunityStore) AddSymptomDailyReports(ctx context.Context, report
 		filter := bson.M{"date": report.Date}
 		update := bson.M{
 			"$set": bson.M{
-				"symptoms": report.Symptoms,
+				"symptoms":                     report.Symptoms,
+				"checkins_num_past_three_days": report.CheckinsNumPastThreeDays,
 			},
 		}
 		_, err := m.Resource("symptom_reports").UpdateOne(ctx, filter, update, opts)
@@ -44,14 +48,15 @@ type Bucket struct {
 	Value int    `bson:"value" json:"value"`
 }
 
-func (m *mongoCommunityStore) GetSymptomReportItems(ctx context.Context, start, end string) (map[string][]Bucket, error) {
+func (m *mongoCommunityStore) GetSymptomReportItems(ctx context.Context, end string, limit int64) (map[string][]Bucket, error) {
 	pipeline := mongo.Pipeline{
 		AggregationMatch(bson.M{
 			"date": bson.M{
-				"$gte": start,
-				"$lt":  end,
+				"$lte": end,
 			},
 		}),
+		AggregationSort("date", -1),
+		AggregationLimit(limit),
 		AggregationUnwind("$symptoms"),
 		AggregationGroup("$symptoms.name", bson.D{
 			bson.E{
@@ -77,4 +82,12 @@ func (m *mongoCommunityStore) GetSymptomReportItems(ctx context.Context, start, 
 		results[aggItem.ID] = aggItem.Buckets
 	}
 	return results, nil
+}
+
+func (m *mongoCommunityStore) FindLatestDailyReport(ctx context.Context) (*SymptomDailyReport, error) {
+	var report SymptomDailyReport
+
+	opts := options.FindOne().SetSort(bson.D{{"date", -1}})
+	err := m.Resource("symptom_reports").FindOne(ctx, bson.M{}, opts).Decode(&report)
+	return &report, err
 }

--- a/store/symptom_report_test.go
+++ b/store/symptom_report_test.go
@@ -1,0 +1,138 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+var (
+	reports = []interface{}{
+		SymptomDailyReport{
+			Date: "2020-07-19",
+			Symptoms: []SymptomStats{
+				{Name: "Cough", Count: 10},
+				{Name: "Fatigue", Count: 18},
+			},
+			CheckinsNumPastThreeDays: 0,
+		},
+		SymptomDailyReport{
+			Date: "2020-07-20",
+			Symptoms: []SymptomStats{
+				{Name: "Cough", Count: 7},
+				{Name: "Fatigue", Count: 28},
+			},
+			CheckinsNumPastThreeDays: 0,
+		},
+		SymptomDailyReport{
+			Date: "2020-07-21",
+			Symptoms: []SymptomStats{
+				{Name: "Cough", Count: 8},
+				{Name: "Fatigue", Count: 29},
+			},
+			CheckinsNumPastThreeDays: 1003,
+		}}
+)
+
+type SymptomReportTestSuite struct {
+	suite.Suite
+	connURI     string
+	mongoClient *mongo.Client
+}
+
+func NewSymptomReportTestSuite(connURI string) *SymptomReportTestSuite {
+	return &SymptomReportTestSuite{
+		connURI: connURI,
+	}
+}
+
+func (s *SymptomReportTestSuite) SetupSuite() {
+	if s.connURI == "" {
+		s.T().Fatal("invalid test suite configuration")
+	}
+
+	opts := options.Client().ApplyURI(s.connURI)
+	mongoClient, err := mongo.NewClient(opts)
+	if nil != err {
+		s.T().Fatalf("create mongo client with error: %s", err)
+	}
+
+	ctx := context.Background()
+	if err = mongoClient.Connect(ctx); nil != err {
+		s.T().Fatalf("connect mongo database with error: %s", err.Error())
+	}
+
+	s.mongoClient = mongoClient
+
+	dbNames, err := mongoClient.ListDatabaseNames(ctx, bson.M{"name": primitive.Regex{Pattern: "^testcase_"}})
+	if err != nil {
+		s.T().Fatalf("list all databases with error: %s", err.Error())
+	}
+
+	for _, name := range dbNames {
+		if err := mongoClient.Database(name).Drop(ctx); err != nil {
+			s.T().Fatalf("drop database with error: %s", err.Error())
+		}
+	}
+
+	if err := s.LoadFixtures(); err != nil {
+		s.T().Fatalf("load fixtures with error: %s", err.Error())
+	}
+}
+
+func (s *SymptomReportTestSuite) SetupTest() {}
+
+func (s *SymptomReportTestSuite) LoadFixtures() error {
+	ctx := context.Background()
+	if _, err := s.mongoClient.Database("testcase_community").Collection("symptom_reports").InsertMany(ctx, reports); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SymptomReportTestSuite) TestCommunityGetSymptomReportItems() {
+	dataPool := NewMongodbDataPool(s.mongoClient, TestDBPrefix)
+
+	ctx := context.Background()
+	items, err := dataPool.Community().GetSymptomReportItems(ctx, "2020-07-21", 7)
+	s.NoError(err)
+	s.Equal(map[string][]Bucket{
+		"Cough": {
+			{"2020-07-21", 8},
+			{"2020-07-20", 7},
+			{"2020-07-19", 10},
+		},
+		"Fatigue": {
+			{"2020-07-21", 29},
+			{"2020-07-20", 28},
+			{"2020-07-19", 18},
+		},
+	}, items)
+
+	items, err = dataPool.Community().GetSymptomReportItems(ctx, "2020-07-18", 7)
+	s.NoError(err)
+	s.Equal(0, len(items))
+}
+
+func (s *SymptomReportTestSuite) TestCommunityFindLatestDailyReport() {
+	ctx := context.Background()
+	report, err := NewMongodbDataPool(s.mongoClient, TestDBPrefix).Community().FindLatestDailyReport(ctx)
+	s.NoError(err)
+	s.Equal(&SymptomDailyReport{
+		Date: "2020-07-21",
+		Symptoms: []SymptomStats{
+			{Name: "Cough", Count: 8},
+			{Name: "Fatigue", Count: 29},
+		},
+		CheckinsNumPastThreeDays: 1003,
+	}, report)
+}
+
+func TestSymptomReport(t *testing.T) {
+	suite.Run(t, NewSymptomReportTestSuite("mongodb://127.0.0.1:27017/?compressors=disabled"))
+}


### PR DESCRIPTION
The aggregated symptom report by Berkeley is a CSV file. The following table is an example.

|items                       |2020-07-19|2020-07-20|2020-07-21|
|-------------------------------|----------|----------|----------|
|Cough                          |10        |7         |8         |
|Fatigue                        |18        |28        |29        |
|Feverish                       |1         |0         |1         |
|Gastrointestinal symptoms      |11        |17        |18        |
|Loss of sense of taste or smell|6         |3         |2         |
|Muscle pain or body aches      |7         |12        |4         |
|Respiratory symptoms           |12        |6         |6         |
|Sore throat                    |18        |18        |11        |
|numberCheckInOnce_Last3days    |NA        |NA        |1003      |

The CSV file will be updated twice a week. Each time we can get the number of participants who have checked in this period of time. In the above example, 1003 people have checked in during 07/19 - 07/21.
